### PR TITLE
Use send_file to return the template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'modsulator'
+gem 'modsulator', '~> 1.1'
 gem 'stanford-mods-normalizer'
 gem 'honeybadger'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       thor (~> 0.19.4)
       tins (~> 1.6)
     crass (1.0.3)
+    deprecation (0.99.0)
+      activesupport
     diff-lcs (1.3)
     dlss-capistrano (3.4.1)
       capistrano (~> 3.0)
@@ -99,11 +101,13 @@ GEM
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    modsulator (1.0.5)
+    modsulator (1.1.0)
       activesupport
+      deprecation (~> 0)
       equivalent-xml (>= 0.6.0)
       nokogiri
       roo (= 2.5.1)
+      stanford-mods-normalizer (~> 0.1)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
@@ -208,7 +212,7 @@ DEPENDENCIES
   equivalent-xml (>= 0.6.0)
   honeybadger
   listen (~> 3.0.5)
-  modsulator
+  modsulator (~> 1.1)
   puma (~> 3.0)
   rails (~> 5.0.2)
   rspec-rails (~> 3.5)

--- a/app/controllers/spreadsheet_controller.rb
+++ b/app/controllers/spreadsheet_controller.rb
@@ -1,5 +1,5 @@
 class SpreadsheetController < ApplicationController
   def index
-    render body: Modsulator.get_template_spreadsheet()
+    send_file Modsulator.template_spreadsheet_path
   end
 end

--- a/spec/controllers/spreadsheet_controller_spec.rb
+++ b/spec/controllers/spreadsheet_controller_spec.rb
@@ -3,15 +3,14 @@ require 'rails_helper'
 RSpec.describe SpreadsheetController, type: :controller do
 
   describe 'GET #index' do
-    let(:io) { StringIO.new("The file contents")}
     before do
-      allow(Modsulator).to receive(:get_template_spreadsheet).and_return(io)
+      allow(Modsulator).to receive(:template_spreadsheet_path).and_return('send/file.xlsx')
     end
 
     it 'returns the spreadsheet template' do
+      expect(controller).to receive(:send_file).with('send/file.xlsx')
       get :index
       expect(response).to have_http_status(:success)
-      expect(response.body).to eq "The file contents"
     end
   end
 end


### PR DESCRIPTION
This is more memory efficent (doesn't load the whole file into memory)

Waiting on a release of modsulator 1.1.0