### PR TITLE
Add a guard clause for blank rows in the xlsx file

### DIFF
--- a/lib/modsulator.rb
+++ b/lib/modsulator.rb
@@ -59,6 +59,8 @@ class Modsulator
     root = full_doc.root
 
     @rows.each do |row|
+      next if row['druid'].nil?
+
       mods_xml_doc = row_to_xml(row)
       sub_doc = full_doc.create_element('xmlDoc', { id: 'descMetadata', objectId: "#{row['druid']}" })
       sub_doc.add_child(mods_xml_doc.root)
@@ -159,7 +161,6 @@ class Modsulator
   # @param row     A single row in a MODS metadata spreadsheet, as provided by the {ModsulatorSheet#rows} method.
   # @return        An instance of Nokogiri::XML::Document that holds a normalized MODS XML instance.
   def row_to_xml(row)
-
     # Generate an XML string, then remove any text carried over from the template
     mods_xml = generate_xml(row)
     mods_xml.gsub!(/\[\[[^\]]+\]\]/, '')


### PR DESCRIPTION
Fixes: https://app.honeybadger.io/projects/55326/faults/42340810#notice-summary by not including any blanks lines from the excel file in the output mods xml.

There is not currently a test for this method. Working on adding and happy to get it into this PR or a follow up.