### PR TITLE
tell coveralls it's a rails app

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@
 FIXTURES_DIR = File.expand_path('fixtures', __dir__)
 
 require 'coveralls'
-Coveralls.wear!
+Coveralls.wear!('rails')
 require 'equivalent-xml/rspec_matchers'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Why was this change made?

Telling coveralls it's a Rails app means it will give more accurate stats on code coverage.

## Was the API documentation updated?

N/A