### PR TITLE
remove tzinfo-data gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,3 @@ group :deploy do
   gem 'capistrano-rails'
   gem 'dlss-capistrano'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   stanford-mods-normalizer
-  tzinfo-data
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
## Why was this change made?

we don't run this code on windows or jruby, so don't need gem specific to those platforms

## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?

n/a