### PR TITLE
Add qa deploy stage

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+server 'modsulator-app-qa.stanford.edu', user: 'modsulator', roles: %w[web db app]
+
+set :rails_env, 'production'
+set :bundle_without, %w[test development deploy].join(' ')
+
+Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
## Why was this change made?

to make modsulator deployable to the new qa server

## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?

docs will be updated once qa/stage/prod cutover is complete

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

argo qa will need to point to modsulator qa
