### PR TITLE
Add 2.6.5 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: ruby
 script: bundle exec rake
 rvm:
   - 2.5.3
+  - 2.6.5


### PR DESCRIPTION
## Why was this change made?

I was unable to successfully deploy to the new qa environment without upgrading ruby, passenger, and bundler

## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?

Docs will be updated once the OS migration is complete

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

Integration with other services is the same, this change is internal to modsulator.
