### PR TITLE
Point stage deploy to upgraded vm

### DIFF
--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-server 'modsulator-app-rails-stage.stanford.edu', user: 'modsulator', roles: %w[web db app]
+server 'modsulator-app-stage.stanford.edu', user: 'modsulator', roles: %w[web db app]
 
 set :rails_env, 'production'
 set :bundle_without, %w[test development deploy].join(' ')


### PR DESCRIPTION
## Why was this change made?

To deploy modsulator app to the newly upgraded stage vm

## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?

Docs will be upgraded once the migration is complete

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

Yes, see https://github.com/sul-dlss/shared_configs/pull/1244
