### PR TITLE
Unpin roo.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,7 @@ gem 'okcomputer'
 gem 'puma', '~> 5.3' # the app server
 gem 'rails', '~> 6.1.0'
 # Parse spreadsheet uploads with roo
-# Pin roo dependency to a thus far unreleased commit that brings Ruby 3 compatibility
-gem 'roo', github: 'roo-rb/roo', ref: '868d4ea419cf393c9d8832838d96c82e47116d2f' # '>= 2.7.1'
+gem 'roo', '~> 2.9'
 gem 'stanford-mods-normalizer'
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/roo-rb/roo.git
-  revision: 868d4ea419cf393c9d8832838d96c82e47116d2f
-  ref: 868d4ea419cf393c9d8832838d96c82e47116d2f
-  specs:
-    roo (2.8.3)
-      nokogiri (~> 1)
-      rubyzip (>= 1.3.0, < 3.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -191,6 +182,9 @@ GEM
       ffi (~> 1.0)
     regexp_parser (2.2.1)
     rexml (3.2.5)
+    roo (2.9.0)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.4)
@@ -282,7 +276,7 @@ DEPENDENCIES
   okcomputer
   puma (~> 5.3)
   rails (~> 6.1.0)
-  roo!
+  roo (~> 2.9)
   rspec-rails (~> 3.5)
   rspec_junit_formatter
   rubocop (~> 1.24)


### PR DESCRIPTION
## Why was this change made? 🤔
roo release now supports ruby 3.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration bulk_update_metadata_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡

Not.
