### PR TITLE
Enforce ruby 3.0.3 at deploy and bundle time

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '3.0.3'
+ruby '3.1.2'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source 'https://rubygems.org'
 
+ruby '3.0.3'
+
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
   "https://github.com/#{repo_name}.git"
@@ -42,5 +44,5 @@ end
 group :deploy do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
-  gem 'dlss-capistrano'
+  gem 'dlss-capistrano', github: 'sul-dlss/dlss-capistrano', branch: 'ruby-version-reporting'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/sul-dlss/dlss-capistrano.git
-  revision: 6104bb256d4f5881db73259be11449bd69eb5a13
+  revision: bf053625cf8619cd55da826c12a7a8b73028bef5
   branch: ruby-version-reporting
   specs:
     dlss-capistrano (4.1.1)
@@ -297,7 +297,7 @@ DEPENDENCIES
   stanford-mods-normalizer
 
 RUBY VERSION
-   ruby 3.0.3p157
+   ruby 3.1.2p20
 
 BUNDLED WITH
    2.3.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/sul-dlss/dlss-capistrano.git
+  revision: 6104bb256d4f5881db73259be11449bd69eb5a13
+  branch: ruby-version-reporting
+  specs:
+    dlss-capistrano (4.1.1)
+      capistrano (~> 3.0)
+      capistrano-bundle_audit (>= 0.3.0)
+      capistrano-one_time_key
+      capistrano-rvm
+      capistrano-shared_configs
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -88,6 +100,9 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
+    capistrano-rvm (0.1.2)
+      capistrano (~> 3.0)
+      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     concurrent-ruby (1.1.10)
     coveralls (0.8.23)
@@ -100,11 +115,6 @@ GEM
     deprecation (1.1.0)
       activesupport
     diff-lcs (1.5.0)
-    dlss-capistrano (4.1.1)
-      capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.3.0)
-      capistrano-one_time_key
-      capistrano-shared_configs
     docile (1.4.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
@@ -269,7 +279,7 @@ DEPENDENCIES
   capistrano-rails
   coveralls
   deprecation
-  dlss-capistrano
+  dlss-capistrano!
   equivalent-xml (>= 0.6.0)
   honeybadger
   listen (~> 3.0.5)
@@ -285,6 +295,9 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   stanford-mods-normalizer
+
+RUBY VERSION
+   ruby 3.0.3p157
 
 BUNDLED WITH
    2.3.4

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -38,22 +38,5 @@ set :linked_dirs, %w[log tmp]
 # we want prod rather than production
 set :honeybadger_env, fetch(:stage)
 
-namespace :deploy do
-  task :restart do
-    on roles(:app), in: :sequence, wait: 5 do
-      # Your restart mechanism here, for example:
-      # execute :touch, release_path.join('tmp/restart.txt')
-    end
-  end
-
-  after :publishing, :restart
-
-  after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
-    end
-  end
-end
+# Prevent deployment if application ruby not installed
+set :validate_ruby_on_deploy, true


### PR DESCRIPTION
## Why was this change made? 🤔

To make it clearer what version of Ruby is required, and to make sure that version of Ruby is installed on servers before deploying.

## How was this change tested? 🤨

Tested by deploying to QA
