### PR TITLE
Remove deprecated method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ end
 
 gem 'rails', '~> 7.0.0'
 
-gem 'deprecation'
 gem 'honeybadger'
 gem 'okcomputer'
 gem 'puma', '~> 5.3' # the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,8 +97,6 @@ GEM
     capistrano-shared_configs (0.2.2)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
-    deprecation (1.1.0)
-      activesupport
     diff-lcs (1.5.0)
     digest (3.1.0)
     dlss-capistrano (4.3.1)
@@ -263,7 +261,6 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  deprecation
   dlss-capistrano
   equivalent-xml (>= 0.6.0)
   honeybadger

--- a/app/lib/modsulator.rb
+++ b/app/lib/modsulator.rb
@@ -6,9 +6,6 @@
 # The main class for the MODSulator API, which lets you work with metadata spreadsheets and MODS XML.
 # @see https://consul.stanford.edu/display/chimera/MODS+bulk+loading Requirements (Stanford Consul page)
 class Modsulator
-  extend Deprecation
-  self.deprecation_horizon = 'modsulator version 2.0.0'
-
   # We define our own namespace for <xmlDocs>
   NAMESPACE = 'http://library.stanford.edu/xmlDocs'
 
@@ -170,18 +167,8 @@ class Modsulator
   end
 
   class << self
-    # Returns the template spreadsheet that's built into this code.
-    #
-    # @return [String] The template spreadsheet, in binary form.
-    def template_spreadsheet
-      File.read(File.expand_path('modsulator/modsulator_template.xlsx', __dir__), mode: 'rb')
-    end
-    deprecation_deprecate :template_spreadsheet
-
     # This can be used by modsulator-rails-app so we can do:
     #   send_file Modsulator.template_spreadsheet_path
-    # which is more memory efficient than:
-    #   render body: Modsulator.template_spreadsheet
     # @return [String] the path to the spreadsheet template.
     def template_spreadsheet_path
       File.expand_path('modsulator/modsulator_template.xlsx', __dir__)

--- a/spec/lib/modsulator_spec.rb
+++ b/spec/lib/modsulator_spec.rb
@@ -14,18 +14,6 @@ RSpec.describe Modsulator do
     end
   end
 
-  describe '#get_template_spreadsheet' do
-    subject { described_class.template_spreadsheet }
-
-    it 'returns the correct spreadsheet' do
-      expected_binary_string = File.read(File.join(File.expand_path('../../app/lib/modsulator', __dir__),
-                                                   'modsulator_template.xlsx'),
-                                         mode: 'rb')
-      expect(Deprecation).to receive(:warn)
-      expect(subject).to eq(expected_binary_string)
-    end
-  end
-
   describe '#template_spreadsheet_path' do
     subject { described_class.template_spreadsheet_path }
 


### PR DESCRIPTION
## Why was this change made? 🤔

We don't use this method.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from or writing to another service (or shared file system), ***run [integration bulk_update_metadata_spec.rb](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test manually in [stage|qa] environment, in addition to specs. ⚡


