### PR TITLE
Incorporate shared_configs into capistrano deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -38,22 +38,5 @@ set :linked_dirs, %w[log tmp]
 # we want prod rather than production
 set :honeybadger_env, fetch(:stage)
 
-namespace :deploy do
-  task :restart do
-    on roles(:app), in: :sequence, wait: 5 do
-      # Your restart mechanism here, for example:
-      # execute :touch, release_path.join('tmp/restart.txt')
-    end
-  end
-
-  after :publishing, :restart
-
-  after :restart, :clear_cache do
-    on roles(:web), in: :groups, limit: 3, wait: 10 do
-      # Here we can do anything such as:
-      # within release_path do
-      #   execute :rake, 'cache:clear'
-      # end
-    end
-  end
-end
+# update shared_configs before restarting app
+before 'deploy:restart', 'shared_configs:update'


### PR DESCRIPTION
## Why was this change made? 🤔

This was never set up, I guess? In so doing, also, rip out the boilerplate for custom restart cap tasks which we do not use.


## How was this change tested? 🤨

Deployed to all envs just fine and saw shared_configs actually update
