### PR TITLE
Handle utf-8 CSVs with BOM

### DIFF
--- a/app/models/modsulator_sheet.rb
+++ b/app/models/modsulator_sheet.rb
@@ -36,7 +36,7 @@ class ModsulatorSheet
   # @return [Roo::CSV, Roo::Excel, Roo::Excelx]   A Roo object, whose type depends on the extension of the given filename.
   def spreadsheet
     @spreadsheet ||= case File.extname(@filename)
-                     when '.csv' then Roo::Spreadsheet.open(@file, extension: :csv)
+                     when '.csv' then Roo::Spreadsheet.open(@file, { extension: :csv, csv_options: { encoding: 'bom|utf-8' } })
                      when '.xls' then Roo::Spreadsheet.open(@file, extension: :xls)
                      when '.xlsx' then Roo::Spreadsheet.open(@file, extension: :xlsx)
                      else raise "Unknown file type: #{@filename}"

--- a/spec/features/modsulator_sheet_unit_spec.rb
+++ b/spec/features/modsulator_sheet_unit_spec.rb
@@ -15,5 +15,33 @@ RSpec.describe ModsulatorSheet do
       expect(row['druid']).to be_nil
       expect(row['sourceId']).to eq 'test:002'
     end
+
+    context 'with a utf-8 CSV with BOM' do
+      subject { described_class.new File.join(FIXTURES_DIR, 'utf8_with_bom.csv'), 'utf8_with_bom.csv' }
+
+      it 'uses the right header row' do
+        expect(subject.headers).to include 'druid', 'sourceId'
+      end
+
+      it 'presents each row as a hash' do
+        row = subject.rows.first
+        expect(row['druid']).to eq('gw231rx2566')
+        expect(row['sourceId']).to eq('csv:04')
+      end
+    end
+
+    context 'with a utf-8 CSV without BOM' do
+      subject { described_class.new File.join(FIXTURES_DIR, 'utf8_without_bom.csv'), 'utf8_without_bom.csv' }
+
+      it 'uses the right header row' do
+        expect(subject.headers).to include 'druid', 'sourceId'
+      end
+
+      it 'presents each row as a hash' do
+        row = subject.rows.first
+        expect(row['druid']).to eq('gw231rx2566')
+        expect(row['sourceId']).to eq('csv:04')
+      end
+    end
   end
 end

--- a/spec/fixtures/utf8_with_bom.csv
+++ b/spec/fixtures/utf8_with_bom.csv
@@ -1,0 +1,2 @@
+﻿druid,lo:purl,sourceId,ti1:title,lo:purl
+gw231rx2566,https://sul-purl-stage.stanford.edu/gw231rx2566,csv:04,Photographs: [Bernice Bing in studio; close-up under tree],https://purl.stanford.edu/ks156qx7930

--- a/spec/fixtures/utf8_without_bom.csv
+++ b/spec/fixtures/utf8_without_bom.csv
@@ -1,0 +1,2 @@
+druid,lo:purl,sourceId,ti1:title,lo:purl
+gw231rx2566,https://sul-purl-stage.stanford.edu/gw231rx2566,csv:04,Photographs: [Bernice Bing in studio; close-up under tree],https://purl.stanford.edu/ks156qx7930


### PR DESCRIPTION
## Why was this change made? 🤔
Fixes https://github.com/sul-dlss/argo/issues/4344 by handling UTF-8 CSVs with a BOM character.  

## How was this change tested? 🤨
Unit and via Argo stage's bulk_jobs (which uses modsulator-stage). Andrew tested with CSVs on stage. 



