### PR TITLE
Bump Ruby to 3.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
-  - 'rubocop-rspec'
   - 'rubocop-rails'
+  - 'rubocop-rspec'
+  - 'rubocop-rspec_rails'
 
 inherit_from: .rubocop_todo.yml
 
@@ -174,7 +175,7 @@ RSpec/SubjectDeclaration: # new in 2.5
   Enabled: true
 FactoryBot/SyntaxMethods: # new in 2.7
   Enabled: true
-RSpec/Rails/AvoidSetupHook: # new in 2.4
+RSpecRails/AvoidSetupHook: # new in 2.4
   Enabled: true
 Rails/ActiveRecordCallbacksOrder: # new in 2.7
   Enabled: true
@@ -279,7 +280,7 @@ Capybara/SpecificFinders: # new in 2.13
   Enabled: true
 Capybara/SpecificMatcher: # new in 2.12
   Enabled: true
-RSpec/Rails/HaveHttpStatus: # new in 2.12
+RSpecRails/HaveHttpStatus: # new in 2.12
   Enabled: true
 Rails/ActionControllerFlashBeforeRender: # new in 2.16
   Enabled: true
@@ -336,7 +337,7 @@ Capybara/SpecificActions: # new in 2.14
   Enabled: true
 FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: true
-RSpec/Rails/InferredSpecType: # new in 2.14
+RSpecRails/InferredSpecType: # new in 2.14
   Enabled: true
 Rails/ActionOrder: # new in 2.17
   Enabled: true
@@ -412,9 +413,9 @@ RSpec/RedundantAround: # new in 2.19
   Enabled: true
 RSpec/SkipBlockInsideExample: # new in 2.19
   Enabled: true
-RSpec/Rails/MinitestAssertions: # new in 2.17
+RSpecRails/MinitestAssertions: # new in 2.17
   Enabled: true
-RSpec/Rails/TravelAround: # new in 2.19
+RSpecRails/TravelAround: # new in 2.19
   Enabled: true
 Rails/ResponseParsedBody: # new in 2.18
   Enabled: true
@@ -435,7 +436,7 @@ Style/YAMLFileRead: # new in 1.53
   Enabled: true
 RSpec/ReceiveMessages: # new in 2.23
   Enabled: true
-RSpec/Rails/NegationBeValid: # new in 2.23
+RSpecRails/NegationBeValid: # new in 2.23
   Enabled: true
 
 RSpec/EmptyMetadata: # new in 2.24
@@ -487,4 +488,18 @@ RSpec/RemoveConst: # new in 2.26
 RSpec/RepeatedSubjectCall: # new in 2.27
   Enabled: true
 Rails/EnvLocal: # new in 2.22
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true
+RSpec/EmptyOutput: # new in 2.29
+  Enabled: true
+RSpec/ExpectInLet: # new in 2.30
+  Enabled: true
+RSpec/UndescriptiveLiteralsDescription: # new in 2.29
+  Enabled: true
+Rails/WhereRange: # new in 2.25
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   Exclude:
     - bin/**
     - config/puma.rb

--- a/Gemfile
+++ b/Gemfile
@@ -7,17 +7,14 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'rails', '~> 7.0.0'
-
+gem 'bootsnap', '>= 1.1.0', require: false # Reduces boot times through caching; required in config/boot.rb
 gem 'honeybadger'
+gem 'irb'
 gem 'okcomputer'
 gem 'puma', '~> 5.3' # the app server
-# Parse spreadsheet uploads with roo
-gem 'roo', '~> 2.9'
+gem 'rails', '~> 7.0.0'
+gem 'roo', '~> 2.9' # Parse spreadsheet uploads with roo
 gem 'stanford-mods-normalizer'
-
-# Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,10 @@ GEM
     honeybadger (5.11.1)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    io-console (0.7.2)
+    irb (1.13.1)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
     loofah (2.22.0)
@@ -160,6 +164,8 @@ GEM
     parser (3.3.2.0)
       ast (~> 2.4.1)
       racc
+    psych (5.1.2)
+      stringio
     puma (5.6.8)
       nio4r (~> 2.0)
     racc (1.8.0)
@@ -196,7 +202,11 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
     regexp_parser (2.9.2)
+    reline (0.5.9)
+      io-console (~> 0.5)
     rexml (3.2.9)
       strscan
     roo (2.10.1)
@@ -266,6 +276,7 @@ GEM
       net-ssh (>= 2.8.0)
     stanford-mods-normalizer (0.1.0)
       nokogiri (~> 1.8)
+    stringio (3.1.1)
     strscan (3.1.0)
     thor (1.3.1)
     timeout (0.4.1)
@@ -289,6 +300,7 @@ DEPENDENCIES
   dlss-capistrano
   equivalent-xml (>= 0.6.0)
   honeybadger
+  irb
   okcomputer
   puma (~> 5.3)
   rails (~> 7.0.0)


### PR DESCRIPTION
# Why was this change made?

Testing the Ruby 3.3 upgrade process for next week's patch party.

Includes:
- **Bump Ruby to 3.3**
- **Update Rubocop config per warnings about missing cops, wrong namesspaces, and unloaded extensions**
- **Add irb to Gemfile for more functional production console**

# How was this change tested?

CI
