### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,5 +4,3 @@ server 'modsulator-app-prod.stanford.edu', user: 'modsulator', roles: %w[web db 
 
 set :rails_env, 'production'
 set :bundle_without, %w[test development deploy].join(' ')
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -4,5 +4,3 @@ server 'modsulator-app-qa.stanford.edu', user: 'modsulator', roles: %w[web db ap
 
 set :rails_env, 'production'
 set :bundle_without, %w[test development deploy].join(' ')
-
-Capistrano::OneTimeKey.generate_one_time_key!

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -4,5 +4,3 @@ server 'modsulator-app-stage.stanford.edu', user: 'modsulator', roles: %w[web db
 
 set :rails_env, 'production'
 set :bundle_without, %w[test development deploy].join(' ')
-
-Capistrano::OneTimeKey.generate_one_time_key!


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.